### PR TITLE
Avoiding a mixed org install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ secret.org
 .emacs.desktop*
 .*~
 agent/*
+/#starter-kit-registers.el#

--- a/init.el
+++ b/init.el
@@ -9,6 +9,14 @@
 (setq starter-kit-dir
       (file-name-directory (or load-file-name (buffer-file-name))))
 
+(let ((elisp-dir (expand-file-name "src" starter-kit-dir)))
+    ;; add the src directory to the load path
+    (add-to-list 'load-path elisp-dir)
+    ;; load specific files
+    (when (file-exists-p elisp-dir)
+      (let ((default-directory elisp-dir))
+        (normal-top-level-add-subdirs-to-load-path))))
+ 
 ;; load up the starter kit
 (org-babel-load-file (expand-file-name "starter-kit.org" starter-kit-dir))
 

--- a/starter-kit.org
+++ b/starter-kit.org
@@ -428,14 +428,7 @@ After we've loaded all the Starter Kit defaults, lets load the User's stuff.
          (remove-extension (name)
            (string-match "\\(.*?\\)\.\\(org\\(\\.el\\)?\\|el\\)\\(\\.gpg\\)?$" name)
            (match-string 1 name)))
-    (let ((elisp-dir (expand-file-name "src" starter-kit-dir))
-          (user-dir (expand-file-name user-login-name starter-kit-dir)))
-      ;; add the src directory to the load path
-      (add-to-list 'load-path elisp-dir)
-      ;; load specific files
-      (when (file-exists-p elisp-dir)
-        (let ((default-directory elisp-dir))
-          (normal-top-level-add-subdirs-to-load-path)))
+    (let ((user-dir (expand-file-name user-login-name starter-kit-dir)))
       ;; load system-specific config
       (sk-load system-name)
       ;; load user-specific config


### PR DESCRIPTION
- init.el: Immediately add elisp-src to load path.
- starter-kit.el: removed corresposnding elisp-src reference

init.el immediately uses org-babel-load-file.  If you have
  your org-mode files in /src (tracking the latest version say) then
  calling org-babel-load-file loads some org files bundled with emacs.  This
  results in a mixed org install.  See
  http://orgmode.org/worg/org-faq.html#mixed-install for details.
