### PR TITLE
starter-kit-lisp needs to explicitly require paredit

### DIFF
--- a/starter-kit-lisp.org
+++ b/starter-kit-lisp.org
@@ -30,6 +30,7 @@ combination with the sexp movement functions (=C-M-f= forward, =C-M-b=
 back, =C-M-u= up, =C-M-d= down)
 
 #+begin_src emacs-lisp
+(require 'paredit)
 (defun turn-on-paredit ()
   (paredit-mode +1))
 #+end_src


### PR DESCRIPTION
Currently, doing `(starter-kit-load "lisp")` in a fresh install of the starter kit fails because the file uses functions from paredit-mode but never explicitly requires paredit.  I've just added a `(require 'paredit)` before the first reference.
