### PR TITLE
Remove broken IPython mode support and always use python-mode by default.

### DIFF
--- a/starter-kit-python.org
+++ b/starter-kit-python.org
@@ -29,18 +29,6 @@ supplied by the Python distribution itself.
 (add-to-list 'interpreter-mode-alist '("python" . python-mode))
 #+end_src
 
-** Use IPython if =ipython= command is present
-   :PROPERTIES:
-   :CUSTOM_ID: ipython
-   :END:
-If an =ipython= executable is on the path, then assume that IPython is
-the preferred method python evaluation.
-#+begin_src emacs-lisp
-  (when (executable-find "ipython")
-    (require 'ipython)
-    (setq org-babel-python-mode 'python-mode))
-#+end_src
-
 ** Use Cython mode
    :PROPERTIES:
    :CUSTOM_ID: cython


### PR DESCRIPTION
As discussed in this issue: https://github.com/eschulte/emacs24-starter-kit/issues/37
