### PR TITLE
add berkeley-unix to special handing of FQDN

### DIFF
--- a/starter-kit.org
+++ b/starter-kit.org
@@ -342,7 +342,9 @@ interested in the actual code implementing the starter kit.
 - Work around a bug on OS X where system-name is FQDN.
   #+name: starter-kit-osX-workaround
   #+begin_src emacs-lisp
-    (if (eq system-type 'darwin)
+    (if (or
+        (eq system-type 'darwin)
+        (eq system-type 'berkeley-unix))
         (setq system-name (car (split-string system-name "\\."))))
   #+end_src
 


### PR DESCRIPTION
OpenBSD also reports the FQDN.  Perhaps it should be handled the same way as Darwin.
