### PR TITLE
Fixed org 'begin_src' command, removed trailing whitespace

### DIFF
--- a/starter-kit-haskell.org
+++ b/starter-kit-haskell.org
@@ -18,7 +18,7 @@ You can skip these steps if you've already setup ghc and cabal
   sudo apt-get install ghc cabal-install
   cabal update
 #+end_src
-    
+
 **** OS X [with Homebrew]
 #+begin_src sh
   brew update
@@ -27,8 +27,8 @@ You can skip these steps if you've already setup ghc and cabal
 #+end_src
 
 *** Update cabal
-#+start_src sh
-   cabal install cabal-install
+#+begin_src sh
+  cabal install cabal-install
 #+end_src
 
 *** Set path to ~/.cabal/bin
@@ -72,7 +72,7 @@ pretty lambdas in Haskell code
 
 
 ** Haskell Mode
-*** Install Haskell mode 
+*** Install Haskell mode
 #+begin_src emacs-lisp
   (starter-kit-install-if-needed 'haskell-mode)
 #+end_src
@@ -89,7 +89,7 @@ pretty lambdas in Haskell code
 
 
 ** Stylish Haskell
-A simple Haskell code prettifier. 
+A simple Haskell code prettifier.
 
 This tool tries to help where necessary without getting in the way.
 
@@ -135,7 +135,7 @@ syntax of Haskell. In short-hand it's called SHM and throughout the
 codebase, too. It acts a bit like, and is heavily inspired by,
 paredit-mode for Emacs.
 
-*** Install structured Haskell 
+*** Install structured Haskell
 #+begin_src sh
   cabal install structured-haskell
 #+end_src
@@ -164,4 +164,3 @@ paredit-mode for Emacs.
   (starter-kit-install-if-needed 'flyspell)
   (add-hook 'haskell-mode-hook 'flyspell-prog-mode)
 #+end_src
-    


### PR DESCRIPTION
- Line 30 had an incorrect org tag
- Removed trailing whitespace
