### PR TITLE
Added smex-items to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ places
 .svn
 .DS_Store
 tramp
+smex-items
 .smex-items
 ac-comphist.dat
 ido.last


### PR DESCRIPTION
Starting at nonsequitur/smex@9af674699b7beeaa6670b96a207eaea94f96ac61 smex wants to store its data as `smex-items` instead of `.smex-items`
