### PR TITLE
Correct a code block structure line

### DIFF
--- a/starter-kit-ruby.org
+++ b/starter-kit-ruby.org
@@ -98,7 +98,7 @@ Clear the compilation buffer between test runs.
 
 #+begin_src emacs-lisp
 ;; (add-hook 'ruby-mode-hook 'idle-highlight)
-#+end_src emacs-lisp
+#+end_src
 
 ** Flymake
    :PROPERTIES:
@@ -146,3 +146,4 @@ See [[http://rinari.rubyforge.org/][rinari.rubyforge]] for more information on r
   (setq rinari-major-modes
         '(dired-mode 'ruby-mode  'css-mode 'yaml-mode 'javascript-mode))
 #+end_src
+


### PR DESCRIPTION
Correct a code block structure which has 'emacs-lisp' in the '+#end_src'
line.

@eschulte I believe this caused the html export of this code block to not export correctly (see <url>http://eschulte.github.io/emacs24-starter-kit/starter-kit-ruby.html</url>). 
